### PR TITLE
Makefile runs or skips solutions based on presence/absence of arch- flag files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ benchmark: $(SOLUTIONS)
 			OUTPUT="$(OUTPUT_DIR)/$${NAME}.out"; \
 			echo "[*] Running $${NAME}" && docker run --rm $$(docker build -q $$s) | tee "$${OUTPUT}"; \
 		else \
-			echo "$$?: [*] Skipping $${NAME} due to architecture mismatch"; \
+			echo "[*] Skipping $${NAME} due to architecture mismatch"; \
 		fi; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+SHELL := /bin/bash
+
 .ONESHELL:
 
 SOLUTIONS  := $(shell find Prime* -type f -name Dockerfile -exec dirname {} \; | sed -e 's|^./||' | sort)
 OUTPUT_DIR := $(shell mktemp -d)
+ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) echo arch-arm64 ;; esac}
 
 all: report
 	@echo "Output files available in $(OUTPUT_DIR)"
@@ -9,8 +12,13 @@ all: report
 benchmark: $(SOLUTIONS)
 	@for s in $(SOLUTIONS); do \
 		NAME=$$(echo "$${s}" | sed -r 's/\//-/g' | tr '[:upper:]' '[:lower:]'); \
-		OUTPUT="$(OUTPUT_DIR)/$${NAME}.out"; \
-		echo "[*] Running $${NAME}" && docker run --rm $$(docker build -q $$s) | tee "$${OUTPUT}"; \
+		ls $${s}/arch-* > /dev/null 2>&1 ; \
+		if [[ -z "$${s}/$(ARCH_FILE)" || -f "$${s}/$(ARCH_FILE)" || "$$?" -ne 0 ]]; then \
+			OUTPUT="$(OUTPUT_DIR)/$${NAME}.out"; \
+			echo "[*] Running $${NAME}" && docker run --rm $$(docker build -q $$s) | tee "$${OUTPUT}"; \
+		else \
+			echo "$$?: [*] Skipping $${NAME} due to architecture mismatch"; \
+		fi; \
 	done
 
 report: benchmark


### PR DESCRIPTION
Runs a solution if:

- the solution directory contains an arch- flag file for the architecture of the runner (as derived from uname -m), or
- the runner architecture is unknown (neither x86_64 nor aarch64); or
- the solution directory contains no arch- flag files